### PR TITLE
README: require SDK v0.1.0 for three samples

### DIFF
--- a/lightdb-led-ipsp/README.rst
+++ b/lightdb-led-ipsp/README.rst
@@ -12,6 +12,23 @@ Requirements
 
 - Golioth credentials
 - Network connectivity
+- Golioth Zephyr SDK v0.1.0
+
+To checkout SDK v0.1.0 for vanilla Zephyr:
+
+```
+cd ~/golioth-zephyr-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
+
+Similarly, to checkout SDK v0.1.0 for NCS Zephyr:
+
+```
+cd ~/golioth-ncs-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
 
 Building and Running
 ********************
@@ -241,3 +258,9 @@ as:
 - ``/aliases/led1``
 - ``/aliases/led2``
 - ``/aliases/led3``
+
+TODO
+****
+- Add tinycbor support to this repo, since it is no longer supported in the Golioth
+  Zephyr SDK after v0.1.0. That would allow this sample to stay up to date with the SDK,
+  and not be stuck on v0.1.0.

--- a/settings_mcumgr/README.rst
+++ b/settings_mcumgr/README.rst
@@ -13,6 +13,23 @@ Requirements
 
 - Golioth credentials
 - Network connectivity
+- Golioth Zephyr SDK v0.1.0
+
+To checkout SDK v0.1.0 for vanilla Zephyr:
+
+```
+cd ~/golioth-zephyr-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
+
+Similarly, to checkout SDK v0.1.0 for NCS Zephyr:
+
+```
+cd ~/golioth-ncs-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
 
 Building and Running
 ********************
@@ -145,6 +162,12 @@ This is the output from the serial console of nRF52840 DK + ESP32-WROOM-32:
    [00:00:06.547,180] <inf> golioth_system: Client connected!
    [00:00:10.561,370] <inf> golioth_hello: Sending hello! 1
    [00:00:15.565,368] <inf> golioth_hello: Sending hello! 2
+
+TODO
+****
+- Add mcumgr support to this repo, since it is no longer supported in the Golioth
+  Zephyr SDK after v0.1.0. That would allow this sample to stay up to date with the SDK,
+  and not be stuck on v0.1.0.
 
 .. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/weather-sensor/README.rst
+++ b/weather-sensor/README.rst
@@ -25,6 +25,23 @@ Requirements
 
 - Golioth credentials
 - Network connectivity
+- Golioth Zephyr SDK v0.1.0
+
+To checkout SDK v0.1.0 for vanilla Zephyr:
+
+```
+cd ~/golioth-zephyr-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
+
+Similarly, to checkout SDK v0.1.0 for NCS Zephyr:
+
+```
+cd ~/golioth-ncs-workspace/modules/lib/golioth
+git checkout v0.1.0
+west update
+```
 
 Building and Running
 ********************
@@ -96,6 +113,12 @@ This is the output from the serial console:
    [00:04:40.939,880] <inf> golioth_bme380: temp: 27.750000; press: 98.283949; humidity: 30.223632
    [00:04:45.941,589] <inf> golioth_bme380: temp: 27.750000; press: 98.283781; humidity: 30.223632
    [00:04:50.943,267] <inf> golioth_bme380: temp: 27.750000; press: 98.283558; humidity: 30.223632
+
+TODO
+****
+- Add mcumgr support to this repo, since it is no longer supported in the Golioth
+  Zephyr SDK after v0.1.0. That would allow this sample to stay up to date with the SDK,
+  and not be stuck on v0.1.0.
 
 .. _Datacake/Golioth integration: https://docs.golioth.io/cloud/output-streams/datacake
 .. _Datacake guide: https://docs.datacake.de/integrations/golioth


### PR DESCRIPTION
Related SDK PR: https://github.com/golioth/golioth-zephyr-sdk/pull/199

Updating the READMEs of three samples to make it explicit that they
require SDK v0.1.0 (the last one to support tinycbor and mcumgr).

Added a TODO section as well, so that we remember to fix this
later, lest these samples be stuck on v0.1.0 forever.

### Testing

To test, I attempted to build all samples with the latest version of the SDK from the linked SDK PR, to see what breaks when mcumgr and tinycbor is removed. The samples fell into these categories:

1. Built successfully: `desired-state`
2. Failed to build due to mcumgr dependency: `settings_mcumgr`, `weather-sensor`
3. Failed to build due to tinycbor dependency: `lightdb-led-ipsp`
4. Failed to build due to using non-standard Zephyr/NCS version: `openthread`
5. Failed to build due to reasons unrelated to tinycbor/mcumgr (could be user error): `sensors/bh1749`

For categories 2 and 3, I then checked out v0.1.0 of the SDK, did a west update, and verified they built succesfully.

For categories 2 and 3, I've updated the READMEs to make it clear that they depend on SDK v0.1.0. I didn't touch the others, since they are unrelated to removal of tinycbor/mcumgr support.